### PR TITLE
Add authors to setup.py

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -12,7 +12,7 @@ setup(
     version='0.1.0',    
     description='A Python package for storing, sharing, and using information about materials in models and simulations.',
     url='https://code.ornl.gov/mist/mist',
-    author='Stephen DeWitt',
+    author='Stephen DeWitt, Gerry Knapp, Hope Spuck, Sam Reeve',
     author_email='dewittsj@ornl.gov',
     license='BSD 3-Clause',
     packages=['mistlib'],


### PR DESCRIPTION
This PR adds Gerry Knapp, @hespuck19, and @streeve to the author list. PEP 345 and PEP 566 are somewhat ambiguous on how to acknowledge multiple authors in a setup.py file. [This StackOverFlow post]( https://stackoverflow.com/questions/9999829/how-to-specify-multiple-authors-emails-in-setup-py) suggests listing the authors in a single string -- a list is not supported. That's what I do here. In the longer term we should probably move to a pyproject.toml file instead.